### PR TITLE
Remove cache / cc user agent headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "configcat-js-ssr",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-js-ssr",
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",
-        "configcat-common": "^5.3.0"
+        "configcat-common": "^6.0.0"
       },
       "devDependencies": {
         "@types/chai": "^4.2.4",
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/configcat-common": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.3.0.tgz",
-      "integrity": "sha512-yM9SNuG8XQa0aHNK5eUhtzAD+a6yFEOQw0qg6f/ZvIWGHkY+7FYvDbSkvMHW1ERQaUmAIt2QLZB6rMJzFCDCmg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+      "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -12152,9 +12152,9 @@
       }
     },
     "configcat-common": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.3.0.tgz",
-      "integrity": "sha512-yM9SNuG8XQa0aHNK5eUhtzAD+a6yFEOQw0qg6f/ZvIWGHkY+7FYvDbSkvMHW1ERQaUmAIt2QLZB6rMJzFCDCmg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+      "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
     },
     "connect": {
       "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-js-ssr",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "ConfigCat Feature Flags for Server Side Rendered apps like NuxtJS. Official ConfigCat SDK for Server Side Rendered to easily access feature flags.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "configcat-common": "^5.3.0"
+    "configcat-common": "^6.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.4",

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -4,7 +4,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 
 export class HttpConfigFetcher implements IConfigFetcher {
 
-    fetchLogic(options: OptionsBase, lastEtag: string, callback: (result: FetchResult) => void): void {
+    fetchLogic(options: OptionsBase, _lastEtag: string, callback: (result: FetchResult) => void): void {
 
         const axiosConfig: AxiosRequestConfig = {
             method: 'get',

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -1,4 +1,4 @@
-import { IConfigFetcher, ProjectConfig, OptionsBase, FetchResult } from "configcat-common";
+import { IConfigFetcher, OptionsBase, FetchResult } from "configcat-common";
 import axios, { AxiosRequestConfig } from 'axios';
 
 
@@ -10,10 +10,6 @@ export class HttpConfigFetcher implements IConfigFetcher {
             method: 'get',
             timeout: options.requestTimeoutMs,
             url: options.getUrl(),
-            headers: {
-                'X-ConfigCat-UserAgent': options.clientVersion,
-                'If-None-Match': (lastEtag) ? lastEtag : null
-            }
         };
 
         axios(axiosConfig)


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR removes the `If-None-Match` and `X-ConfigCat-UserAgent` request headers. The SDK version is now a query param in the fetch URL, and we let the browser send the `If-None-Match` and `If-Modified-Since` headers.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
