### PR TITLE
Fix failing setup of GitHub Actions checks

### DIFF
--- a/.github/workflows/js-ssr-ci.yml
+++ b/.github/workflows/js-ssr-ci.yml
@@ -13,7 +13,7 @@ on:
   
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test on latest Chrome and report coverage
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
           path: configcat-js-ssr*.tgz
 
   test-chrome:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         chrome: ["beta", "stable"]
@@ -112,7 +112,7 @@ jobs:
         run: CHROMIUM_BIN=$(which chrome) npm run test-chromium
 
   test-firefox:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         firefox: ["84.0", "latest-beta", "latest"]


### PR DESCRIPTION
### Describe the purpose of your pull request

It seems that the [migration](https://dev.to/siddhantkcode/critical-changes-coming-to-github-actions-ubuntu-24-migration-guide-oo8) of the `ubuntu-latest` runner image from 22.04 to 24.04 breaks the setup of some GitHub Actions checks. E.g. `browser-actions/setup-chrome@latest` and `browser-actions/setup-firefox@latest` seem to have compatibility issues with the latest Ubuntu image.

So, as a temporary workaround, we pin the Ubuntu image version to 22.04 for the problematic checks.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
