### PR TITLE
Update Node.js version used for GitHub checks

### DIFF
--- a/.github/workflows/js-ssr-ci.yml
+++ b/.github/workflows/js-ssr-ci.yml
@@ -29,7 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install codecov -g
+          mkdir -p coverage
+          curl -s -o coverage/codecov https://uploader.codecov.io/latest/linux/codecov
+          chmod +x coverage/codecov
           npm install
 
       - name: Build
@@ -38,10 +40,10 @@ jobs:
           npm run buildPure
 
       - name: Coverage
-        run: npm run test
+        run: CHROME_BIN=$(which chrome) npm run test
 
       - name: Upload coverage report
-        run: codecov
+        run: coverage/codecov -t ${CODECOV_TOKEN}
 
       - name: 📦Pack
         run: npm pack

--- a/.github/workflows/js-ssr-ci.yml
+++ b/.github/workflows/js-ssr-ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Setup chrome
         uses: browser-actions/setup-chrome@latest
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Setup chrome
         uses: browser-actions/setup-chrome@latest
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Setup chrome
         id: setup-chrome
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest


### PR DESCRIPTION
### Describe the purpose of your pull request
The GitHub workflow defining checks uses Node 14, which seems too old, causing some test runs to fail.

This PR fixes this by updating the Node.js version to use.

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
